### PR TITLE
Remove module load

### DIFF
--- a/RepEnrich.py
+++ b/RepEnrich.py
@@ -127,7 +127,6 @@ fin.close()
 # map the repeats to the psuedogenomes:
 if not os.path.exists(outputfolder):
 	os.mkdir(outputfolder)
-subprocess.call('module load bowtie',shell=True)
 ################################################################################
 # Conduct the regions sorting
 print 'Conducting region sorting on unique mapping reads....'


### PR DESCRIPTION
The documentation already suggests to load the necessary modules before running `repEnrich.py` so this line is redudant. More importantly it assumes the user has `module` in their system, which is not always the case. I keep getting these errors as a result:
> /bin/sh: module: command not found

Cheers